### PR TITLE
Expose port in case of random port assignment

### DIFF
--- a/lib/light-swift.js
+++ b/lib/light-swift.js
@@ -341,6 +341,7 @@
     LightSwift.prototype.server = function() {
       this._server = new SwiftServer(this);
       this._server.listen();
+      this.options.port = this._server.httpServer.address().port;
       return this._server;
     };
 

--- a/src/light-swift.coffee
+++ b/src/light-swift.coffee
@@ -222,6 +222,7 @@ class LightSwift
   server: =>
     @_server = new SwiftServer(@)
     @_server.listen()
+    @options.port = @_server.httpServer.address().port;
     @_server
 
 module.exports = LightSwift


### PR DESCRIPTION
It's possible that you'll just want to expose the httpServer directly so that it can be consumed for other use cases.
